### PR TITLE
Catch protocol handler errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvbcss-protocols",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Javascript library implementing client and server code for DVB CSS sync protocols",
   "browser": "src/main_browser.js",
   "main": "src/main_node.js",

--- a/src/SocketAdaptors/WebSocketAdaptor.js
+++ b/src/SocketAdaptors/WebSocketAdaptor.js
@@ -47,14 +47,19 @@ var WebSocketAdaptor = function(protocolHandler, webSocket) {
 //          //console.log(evt);
 
             var msg;
-            if (evt.binary || typeof evt.data != "string") {
-                msg = new Uint8Array(evt.data).buffer;
-            } else {
-                msg = evt.data;
-            }
 
-            protocolHandler.handleMessage(msg, null); // no routing information
-        }.bind(this)
+            try {
+              if (evt.binary || typeof evt.data != "string") {
+                  msg = new Uint8Array(evt.data).buffer;
+              } else {
+                  msg = evt.data;
+              }
+
+              protocolHandler.handleMessage(msg, null); // no routing information
+            } catch (error) {
+              webSocket.close();
+            }
+          }.bind(this)
     }
 
     webSocket.addEventListener("open",    handlers.open);


### PR DESCRIPTION
If a textual message is sent to the binary protocol handler, the whole process crashes.

This change catches any error thrown in the message handler and only closes the current connection.


To reproduce the bug:

`npm start`

`npx wscat -c 192.168.0.2:6676` (use IP address printed by the service)

`> foo`


<img width="1405" alt="Screenshot 2021-06-11 at 09 23 38" src="https://user-images.githubusercontent.com/22295699/121663667-90540100-ca9e-11eb-8098-d8e8ff6a96f6.png">
<img width="432" alt="Screenshot 2021-06-11 at 09 23 49" src="https://user-images.githubusercontent.com/22295699/121663683-93e78800-ca9e-11eb-9d24-1d0a55a5cba5.png">
